### PR TITLE
Crowded Levels ready for v95

### DIFF
--- a/mutator-crowded-levels/MqKeezy.Sor.Mutator.CrowdedLevels.cs
+++ b/mutator-crowded-levels/MqKeezy.Sor.Mutator.CrowdedLevels.cs
@@ -15,7 +15,7 @@ namespace mqKeezy_Mutator_CrowdedLevels
     [BepInPlugin(ModInfo.BepInExPluginId, ModInfo.Title, ModInfo.Version)]
     public class MqkSorMutatorCrowdedLevels : BaseUnityPlugin
     {
-	    private static ConfigEntry<int> configCrowdedLevelScale;
+        private static ConfigEntry<int> configCrowdedLevelScale;
         private static UnlockBuilder Mutator;
 
         private static readonly MethodInfo applyAgentMultiplierMethodInfo = AccessTools.Method(
@@ -25,32 +25,32 @@ namespace mqKeezy_Mutator_CrowdedLevels
 
         public static int ApplyAgentMultiplier(int bigTries)
         {
-	        return Mutator?.Unlock.IsEnabled == true
-			        ? bigTries * configCrowdedLevelScale.Value / 100
-			        : bigTries;
+            return Mutator?.Unlock.IsEnabled == true
+                    ? bigTries * configCrowdedLevelScale.Value / 100
+                    : bigTries;
         }
 
         private void Awake()
         {
-	        Mutator = RogueLibs.CreateCustomUnlock(new MutatorUnlock(
-					        name: "mqKeezy.CrowdedLevels",
-					        unlockedFromStart: true
-			        ))
-			        .WithName(new CustomNameInfo(english: "Crowded Levels"))
-			        .WithDescription(new CustomNameInfo(english: ""));
+            Mutator = RogueLibs.CreateCustomUnlock(new MutatorUnlock(
+                            name: "mqKeezy.CrowdedLevels",
+                            unlockedFromStart: true
+                    ))
+                    .WithName(new CustomNameInfo(english: "Crowded Levels"))
+                    .WithDescription(new CustomNameInfo(english: ""));
 
-	        configCrowdedLevelScale = Config.Bind(section: "General", key: "CrowdedLevelScale", defaultValue: 300,
+            configCrowdedLevelScale = Config.Bind(section: "General", key: "CrowdedLevelScale", defaultValue: 300,
                 description:
                 "The number of dwellers in all levels will be multiplied by this percentage. Ex: 100 = 100%, 50 = 50%, 300 = 300%.");
 
-	        new Harmony(ModInfo.BepInExHarmonyPatchesId).PatchAll();
+            new Harmony(ModInfo.BepInExHarmonyPatchesId).PatchAll();
         }
         
         private static class Patches
         {
-	        private static class LoadLevelPatch
+            private static class LoadLevelPatch
             {
-	            [PublicAPI]
+                [PublicAPI]
                 [HarmonyPatch]
                 private static class SetupMore3_3
                 {

--- a/mutator-crowded-levels/mutator-crowded-levels.csproj
+++ b/mutator-crowded-levels/mutator-crowded-levels.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -32,25 +32,25 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="0Harmony, Version=2.4.2.0, Culture=neutral, PublicKeyToken=null">
-            <HintPath>libs\0Harmony.dll</HintPath>
+        <Reference Include="0Harmony, Version=2.4.0.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>libs\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>libs\Assembly-CSharp_publicized.dll</HintPath>
         </Reference>
-        <Reference Include="BepInEx, Version=5.4.10.0, Culture=neutral, PublicKeyToken=null">
-            <HintPath>libs\BepInEx.dll</HintPath>
+        <Reference Include="BepInEx, Version=5.4.9.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>libs\BepInEx.dll</HintPath>
         </Reference>
         <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>libs\BepInEx.Harmony.dll</HintPath>
         </Reference>
-        <Reference Include="RogueLibs, Version=2.1.1.0, Culture=neutral, PublicKeyToken=null">
-            <HintPath>libs\RogueLibs.dll</HintPath>
+        <Reference Include="RogueLibsCore, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>libs\RogueLibsCore.dll</HintPath>
         </Reference>
-        <Reference Include="System"/>
-        <Reference Include="System.Core"/>
-        <Reference Include="System.Data"/>
-        <Reference Include="System.Xml"/>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
         <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>libs\UnityEngine.dll</HintPath>
         </Reference>
@@ -65,11 +65,11 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
-        <Compile Include="MqKeezy.Sor.Mutator.CrowdedLevels.cs"/>
-        <Compile Include="Properties\AssemblyInfo.cs"/>
-        <Compile Include="Properties\Mod.Info.cs"/>
+        <Compile Include="MqKeezy.Sor.Mutator.CrowdedLevels.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="Properties\Mod.Info.cs" />
     </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">


### PR DESCRIPTION
Since the LoadLevel logic hasn't changed much this is really just an update to RLv3.

Anyway, I got a little carried away and did some minor refactoring.
Lowered visibility of fields.
Added the `[PublicAPI]` Attribute because the Patchers are run via reflection and thus considered unused.
Changed the Patcher classes to static, since they're never instantiated (and not supposed to be).

Also a bug fix:
Using `configCrowdedLevelScale` values where `value % 100 != 0` would drop the floating point (because `int`).