### PR TITLE
Larger levels v95

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.log
 /bin/
 /.idea
+/*/.idea
+/*/Folder.DotSettings.user
 /disable-trait-conflicts/bin
 /enable-unavailable-items/bin
 /enable-unavailable-traits/bin
@@ -42,3 +44,4 @@
 /mutator-simple-injuries/libs
 /mutator-simple-injuries/obj
 /mutator-simple-injuries/bin
+.editorconfig

--- a/mutator-larger-levels/LoadLevelPatch.cs
+++ b/mutator-larger-levels/LoadLevelPatch.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using JetBrains.Annotations;
+
+namespace mqKeezy_Mutator_LargerLevels
+{
+    [PublicAPI]
+    [HarmonyPatch(typeof(LoadLevel))]
+    public static class LoadLevelPatch
+    {
+        private static readonly FieldInfo levelSizeMaxInfoField =
+            AccessTools.Field(typeof(LoadLevel), nameof(LoadLevel.levelSizeMax));
+
+        private static readonly MethodInfo modifyMaxLevelSizeField =
+            AccessTools.Method(typeof(MqkSorMutatorLargerLevels), nameof(MqkSorMutatorLargerLevels.ModifyMaxLevelSize));
+
+        [HarmonyPatch("CreateInitialMap")]
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> codes = instructions.ToList();
+
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (i > 3 && codes[i - 1].OperandIs(levelSizeMaxInfoField) &&
+                    codes[i - 2].opcode == OpCodes.Ldc_I4_S && codes[i - 3].opcode == OpCodes.Ldarg_0)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Ldfld, levelSizeMaxInfoField);
+                    yield return new CodeInstruction(OpCodes.Call, modifyMaxLevelSizeField);
+                    yield return new CodeInstruction(OpCodes.Stfld, levelSizeMaxInfoField);
+                }
+
+                yield return codes[i];
+            }
+        }
+    }
+}

--- a/mutator-larger-levels/LoadLevelPatch.cs
+++ b/mutator-larger-levels/LoadLevelPatch.cs
@@ -8,7 +8,7 @@ using JetBrains.Annotations;
 namespace mqKeezy_Mutator_LargerLevels
 {
     [PublicAPI]
-    [HarmonyPatch(typeof(LoadLevel))]
+    [HarmonyPatch(declaringType: typeof(LoadLevel))]
     public static class LoadLevelPatch
     {
         private static readonly FieldInfo levelSizeMaxInfoField =
@@ -17,7 +17,7 @@ namespace mqKeezy_Mutator_LargerLevels
         private static readonly MethodInfo modifyMaxLevelSizeField =
             AccessTools.Method(typeof(MqkSorMutatorLargerLevels), nameof(MqkSorMutatorLargerLevels.ModifyMaxLevelSize));
 
-        [HarmonyPatch("CreateInitialMap")]
+        [HarmonyPatch(methodName: "CreateInitialMap")]
         [HarmonyTranspiler]
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {

--- a/mutator-larger-levels/MqKeezy.Sor.Mutator.LargerLevels.cs
+++ b/mutator-larger-levels/MqKeezy.Sor.Mutator.LargerLevels.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using BepInEx;
+﻿using BepInEx;
 using BepInEx.Configuration;
 using HarmonyLib;
 using mqKeezy_Mutator_LargerLevels.Properties;
@@ -14,21 +10,17 @@ namespace mqKeezy_Mutator_LargerLevels
     [BepInPlugin(ModInfo.BepInExPluginId, ModInfo.Title, ModInfo.Version)]
     public class MqkSorMutatorLargerLevels : BaseUnityPlugin
     {
-        public static ConfigEntry<int> configLevelSizePercentage;
-        public static CustomMutator Mutator;
-
-        public static readonly FieldInfo levelSizeMaxInfoField =
-            AccessTools.Field(typeof(LoadLevel), nameof(LoadLevel.levelSizeMax));
-
-        public static readonly MethodInfo modifyMaxLevelSizeField =
-            AccessTools.Method(typeof(MqkSorMutatorLargerLevels), nameof(ModifyMaxLevelSize));
+        private static ConfigEntry<int> configLevelSizePercentage;
+        private static UnlockBuilder Mutator;
 
         private void Awake()
         {
-            Mutator = RogueLibs.CreateCustomMutator(id: "mqKeezy.LargerLevels",
-                unlockedFromStart: true,
-                new CustomNameInfo(english: "Larger Levels"),
-                new CustomNameInfo(english: ""));
+            Mutator = RogueLibs.CreateCustomUnlock(new MutatorUnlock(
+                    name: "mqKeezy.LargerLevels",
+                    unlockedFromStart: true
+                ))
+                .WithName(new CustomNameInfo(english: "Larger Levels"))
+                .WithDescription(new CustomNameInfo(english: ""));
 
             configLevelSizePercentage = Config.Bind(section: "General", key: "LevelSizePercentage", defaultValue: 200,
                 description:
@@ -39,58 +31,9 @@ namespace mqKeezy_Mutator_LargerLevels
 
         public static int ModifyMaxLevelSize(int value)
         {
-            if (Mutator?.IsActive == true)
-            {
-                return (int) Mathf.Clamp(value * (configLevelSizePercentage.Value / 100f), min: 10, max: 64);
-            }
-
-            return value;
-        }
-
-        private static IEnumerable<CodeInstruction> InsertMaxLevelSizeInstructions()
-        {
-            yield return new CodeInstruction(OpCodes.Ldarg_0);
-            yield return new CodeInstruction(OpCodes.Ldarg_0);
-            yield return new CodeInstruction(OpCodes.Ldfld, levelSizeMaxInfoField);
-            yield return new CodeInstruction(OpCodes.Call, modifyMaxLevelSizeField);
-            yield return new CodeInstruction(OpCodes.Stfld, levelSizeMaxInfoField);
-        }
-
-        private static IEnumerable<CodeInstruction> TranspileFields(IEnumerable<CodeInstruction> instructions)
-        {
-            List<CodeInstruction> codes = instructions.ToList();
-
-            for (int i = 0; i < codes.Count; i++)
-            {
-                CodeInstruction t = codes[i];
-                if (i > 3 && codes[i - 1].OperandIs(levelSizeMaxInfoField) &&
-                    codes[i - 2].opcode == OpCodes.Ldc_I4_S && codes[i - 3].opcode == OpCodes.Ldarg_0
-                )
-                {
-                    foreach (CodeInstruction codeInstruction in InsertMaxLevelSizeInstructions())
-                    {
-                        yield return codeInstruction;
-                    }
-                }
-
-                yield return t;
-            }
-        }
-
-        private static class Patches
-        {
-            private static class LoadLevelPatch
-            {
-                [HarmonyPatch(typeof(LoadLevel), nameof(LoadLevel.CreateInitialMap))]
-                private static class CreateInitialMap
-                {
-                    [HarmonyTranspiler]
-                    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-                    {
-                        return TranspileFields(instructions);
-                    }
-                }
-            }
+            return Mutator?.Unlock.IsEnabled == true
+                ? (int) Mathf.Clamp(value * (configLevelSizePercentage.Value / 100f), min: 10, max: 64)
+                : value;
         }
     }
 }

--- a/mutator-larger-levels/mutator-larger-levels.csproj
+++ b/mutator-larger-levels/mutator-larger-levels.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -40,19 +40,19 @@
         <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>libs\Assembly-CSharp_publicized.dll</HintPath>
         </Reference>
-        <Reference Include="BepInEx, Version=5.4.10.0, Culture=neutral, PublicKeyToken=null">
-            <HintPath>libs\BepInEx.dll</HintPath>
+        <Reference Include="BepInEx, Version=5.4.11.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>libs\BepInEx.dll</HintPath>
         </Reference>
         <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>libs\BepInEx.Harmony.dll</HintPath>
         </Reference>
-        <Reference Include="RogueLibs, Version=2.1.1.0, Culture=neutral, PublicKeyToken=null">
-            <HintPath>libs\RogueLibs.dll</HintPath>
+        <Reference Include="RogueLibsCore, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>libs\RogueLibsCore.dll</HintPath>
         </Reference>
-        <Reference Include="System"/>
-        <Reference Include="System.Core"/>
-        <Reference Include="System.Data"/>
-        <Reference Include="System.Xml"/>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
         <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>libs\UnityEngine.dll</HintPath>
         </Reference>
@@ -67,11 +67,12 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
-        <Compile Include="MqKeezy.Sor.Mutator.LargerLevels.cs"/>
-        <Compile Include="Properties\AssemblyInfo.cs"/>
-        <Compile Include="Properties\Mod.Info.cs"/>
+        <Compile Include="LoadLevelPatch.cs" />
+        <Compile Include="MqKeezy.Sor.Mutator.LargerLevels.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="Properties\Mod.Info.cs" />
     </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">


### PR DESCRIPTION
Another RLv3 update.

Added some exclusions to the .gitignore so Rider isn't constantly yelling at me about untracked files.
Created a new Class LoadLevelPatch that holds all the Patcher specific logic. (Maybe just my opinion, but I prefer a 1 file = 1 class structure)
Changed to BepInEx 5.4.11

Note:
BepInEx 5.4.13 works, but Harmony PatchAll is throwing an exception *after* patching, no clue why.