### PR TITLE
Free loadout refills v95

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.log
 /bin/
 /.idea
+/*/.idea
+/*/Folder.DotSettings.user
 /disable-trait-conflicts/bin
 /enable-unavailable-items/bin
 /enable-unavailable-traits/bin
@@ -42,3 +44,4 @@
 /mutator-simple-injuries/libs
 /mutator-simple-injuries/obj
 /mutator-simple-injuries/bin
+.editorconfig

--- a/mutator-free-loadout-refills/MqKeezy.Sor.Mutator.FreeLoadoutRefills.cs
+++ b/mutator-free-loadout-refills/MqKeezy.Sor.Mutator.FreeLoadoutRefills.cs
@@ -8,36 +8,18 @@ namespace mqKeezy_Mutator_FreeLoadoutRefills
     [BepInPlugin(ModInfo.BepInExPluginId, ModInfo.Title, ModInfo.Version)]
     public class MqkSorMutatorFreeLoadoutRefills : BaseUnityPlugin
     {
-        public static CustomMutator Mutator;
+        public static UnlockBuilder Mutator;
 
         public void Awake()
         {
-            Mutator = RogueLibs.CreateCustomMutator(id: "mqKeezy.FreeLoadoutRefills",
-                unlockedFromStart: true,
-                new CustomNameInfo(english: "Free Loadout Refills"),
-                new CustomNameInfo(english: ""));
+            Mutator = RogueLibs.CreateCustomUnlock(new MutatorUnlock(
+                    name: "mqKeezy.FreeLoadoutRefills",
+                    unlockedFromStart: true
+                ))
+                .WithName(new CustomNameInfo(english: "Free Loadout Refills"))
+                .WithDescription(new CustomNameInfo(english: ""));
 
             new Harmony(ModInfo.BepInExHarmonyPatchesId).PatchAll();
-        }
-
-        private class Patches
-        {
-            private class PlayfieldObjectPatch
-            {
-                [HarmonyPatch(typeof(PlayfieldObject),
-                    methodName: "determineMoneyCost",
-                    typeof(InvItem),
-                    typeof(int),
-                    typeof(string))]
-                private class DetermineMoneyCost
-                {
-                    [HarmonyPrefix]
-                    private static bool Prefix(ref string transactionType)
-                    {
-                        return Mutator?.IsActive != true || transactionType != "LoadoutMachine";
-                    }
-                }
-            }
         }
     }
 }

--- a/mutator-free-loadout-refills/PlayfieldObjectPatch.cs
+++ b/mutator-free-loadout-refills/PlayfieldObjectPatch.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using JetBrains.Annotations;
+
+namespace mqKeezy_Mutator_FreeLoadoutRefills
+{
+    [PublicAPI]
+    [HarmonyPatch(declaringType: typeof(PlayfieldObject))]
+    public static class PlayfieldObjectPatch
+    {
+        [HarmonyPatch(
+            methodName: nameof(PlayfieldObject.determineMoneyCost),
+            argumentTypes: new[] { typeof(InvItem), typeof(int), typeof(string) })]
+        [HarmonyPrefix]
+        private static bool Prefix(string transactionType)
+        {
+            return MqkSorMutatorFreeLoadoutRefills.Mutator?.Unlock.IsEnabled != true || transactionType != "LoadoutMachine";
+        }
+    }
+}

--- a/mutator-free-loadout-refills/mutator-free-loadout-refills.csproj
+++ b/mutator-free-loadout-refills/mutator-free-loadout-refills.csproj
@@ -40,14 +40,14 @@
         <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
           <HintPath>libs\Assembly-CSharp_publicized.dll</HintPath>
         </Reference>
-        <Reference Include="BepInEx, Version=5.4.10.0, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="BepInEx, Version=5.4.11.0, Culture=neutral, PublicKeyToken=null">
           <HintPath>libs\BepInEx.dll</HintPath>
         </Reference>
         <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
           <HintPath>libs\BepInEx.Harmony.dll</HintPath>
         </Reference>
-        <Reference Include="RogueLibs, Version=2.1.1.0, Culture=neutral, PublicKeyToken=null">
-          <HintPath>libs\RogueLibs.dll</HintPath>
+        <Reference Include="RogueLibsCore, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>libs\RogueLibsCore.dll</HintPath>
         </Reference>
         <Reference Include="System" />
         <Reference Include="System.Core" />
@@ -68,6 +68,7 @@
     </ItemGroup>
     <ItemGroup>
         <Compile Include="MqKeezy.Sor.Mutator.FreeLoadoutRefills.cs" />
+        <Compile Include="PlayfieldObjectPatch.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="Properties\Mod.Info.cs" />
     </ItemGroup>


### PR DESCRIPTION
Another RLv3 update.

Added some exclusions to the .gitignore so Rider isn't constantly yelling at me about untracked files.
Created a new Class PlayfieldObjectPatch that holds all the Patcher specific logic. (Maybe just my opinion, but I prefer a 1 file = 1 class structure)
Changed to BepInEx 5.4.11

Note:
BepInEx 5.4.13 works, but Harmony PatchAll is throwing an exception after patching, no clue why.