### PR TITLE
Free ammo refills v95 fix

### DIFF
--- a/mutator-free-ammo-refills/MqKeezy.Sor.Mutator.FreeAmmoRefills.cs
+++ b/mutator-free-ammo-refills/MqKeezy.Sor.Mutator.FreeAmmoRefills.cs
@@ -8,32 +8,18 @@ namespace mqKeezy_Mutator_FreeAmmoRefills
     [BepInPlugin(ModInfo.BepInExPluginId, ModInfo.Title, ModInfo.Version)]
     public class MqkSorMutatorAmmoRefills : BaseUnityPlugin
     {
-        public static CustomMutator Mutator;
+        public static UnlockBuilder Mutator;
 
         private void Awake()
         {
-            Mutator = RogueLibs.CreateCustomMutator(id: "mqKeezy.FreeAmmoRefills",
-                unlockedFromStart: true,
-                new CustomNameInfo(english: "Free Ammo Dispenser Refills"),
-                new CustomNameInfo(english: ""));
+            Mutator = RogueLibs.CreateCustomUnlock(new MutatorUnlock(
+                    name: "mqKeezy.FreeAmmoRefills",
+                    unlockedFromStart: true
+                ))
+                .WithName(new CustomNameInfo(english: "Free Ammo Dispenser Refills"))
+                .WithDescription(new CustomNameInfo(english: ""));
 
             new Harmony(ModInfo.BepInExHarmonyPatchesId).PatchAll();
-        }
-
-        private class Patches
-        {
-            private class PlayfieldObjectPatch
-            {
-                [HarmonyPatch(typeof(PlayfieldObject), methodName: "determineMoneyCost", typeof(int), typeof(string))]
-                private class DetermineMoneyCost
-                {
-                    [HarmonyPrefix]
-                    private static bool Prefix(ref string transactionType)
-                    {
-                        return Mutator?.IsActive != true || transactionType != "AmmoDispenser";
-                    }
-                }
-            }
         }
     }
 }

--- a/mutator-free-ammo-refills/PlayfieldObjectPatch.cs
+++ b/mutator-free-ammo-refills/PlayfieldObjectPatch.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+using JetBrains.Annotations;
+
+namespace mqKeezy_Mutator_FreeAmmoRefills
+{
+    [PublicAPI]
+    [HarmonyPatch(declaringType: typeof(PlayfieldObject))]
+    public static class PlayfieldObjectPatch
+    {
+        [HarmonyPatch(methodName: "determineMoneyCost", argumentTypes: new[] { typeof(int), typeof(string) })]
+        [HarmonyPrefix]
+        private static bool Prefix(string transactionType)
+        {
+            return MqkSorMutatorAmmoRefills.Mutator?.Unlock.IsEnabled != true || transactionType != "AmmoDispenser";
+        }
+    }
+}

--- a/mutator-free-ammo-refills/mutator-free-ammo-refills.csproj
+++ b/mutator-free-ammo-refills/mutator-free-ammo-refills.csproj
@@ -40,14 +40,14 @@
         <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
           <HintPath>libs\Assembly-CSharp_publicized.dll</HintPath>
         </Reference>
-        <Reference Include="BepInEx, Version=5.4.10.0, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="BepInEx, Version=5.4.11.0, Culture=neutral, PublicKeyToken=null">
           <HintPath>libs\BepInEx.dll</HintPath>
         </Reference>
         <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
           <HintPath>libs\BepInEx.Harmony.dll</HintPath>
         </Reference>
-        <Reference Include="RogueLibs, Version=2.1.1.0, Culture=neutral, PublicKeyToken=null">
-          <HintPath>libs\RogueLibs.dll</HintPath>
+        <Reference Include="RogueLibsCore, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>libs\RogueLibsCore.dll</HintPath>
         </Reference>
         <Reference Include="System" />
         <Reference Include="System.Core" />
@@ -68,6 +68,7 @@
     </ItemGroup>
     <ItemGroup>
         <Compile Include="MqKeezy.Sor.Mutator.FreeAmmoRefills.cs" />
+        <Compile Include="PlayfieldObjectPatch.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="Properties\Mod.Info.cs" />
     </ItemGroup>


### PR DESCRIPTION
Another RLv3 update (this time without messed up history).

Created a new Class PlayfieldObjectPatch that holds all the Patcher specific logic. (Maybe just my opinion, but I prefer a 1 file = 1 class structure)
Changed to BepInEx 5.4.11

Note:
BepInEx 5.4.13 works, but Harmony PatchAll is throwing an exception after patching, no clue why.